### PR TITLE
Zeroconf support, improved reconnection attempts, add option to specify port for the device and webserver, added number and climate entities, added test devices.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 dist
+venv/

--- a/aioesphomeserver/__init__.py
+++ b/aioesphomeserver/__init__.py
@@ -12,3 +12,4 @@ from .switch import *
 from .web_server import *
 from .light import *
 from .sensor import *
+from .climate import *

--- a/aioesphomeserver/basic_entity.py
+++ b/aioesphomeserver/basic_entity.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import re
 import hashlib
+import socket
+import logging
+from zeroconf.asyncio import AsyncServiceInfo, AsyncZeroconf
 
 class BasicEntity:
     DOMAIN = ""
@@ -86,3 +89,45 @@ class BasicEntity:
             'state_change',
             await self.build_state_response()
         )
+    
+
+    async def register_zeroconf(self, port):
+        logging.info(f"Registering Zeroconf for {self.name} on port {port}")
+        try:
+            zeroconf = AsyncZeroconf()
+            hostname = socket.gethostname()
+            address = socket.gethostbyname(hostname)
+            service_info = AsyncServiceInfo(
+                type_="_esphomelib._tcp.local.",
+                name=f"{self.name}._esphomelib._tcp.local.",
+                addresses=[socket.inet_aton(address)],
+                port=port,
+                properties={
+                    "address": address,
+                    "port": str(port),
+                    "api_version": "1.5.0",
+                    "mac": self.mac_address,
+                    "manufacturer": self.manufacturer,
+                    "model": self.model,
+                    "name": self.name,
+                    "project_name": self.project_name,
+                    "project_version": self.project_version,
+                }
+            )
+            await zeroconf.async_register_service(service_info)
+            logging.info(f"Zeroconf registration successful for {self.name} on port {port}")
+            return zeroconf
+        except Exception as e:
+            logging.error(f"Error registering Zeroconf service for {self.name}: {e}")
+            logging.exception("Exception details:")
+            return None
+
+    async def unregister_zeroconf(self, zeroconf):
+        if zeroconf:
+            service_info = AsyncServiceInfo(
+                type_="_esphomelib._tcp.local.",
+                name=f"{self.device.name}._esphomelib._tcp.local."
+            )
+            await zeroconf.async_unregister_service(service_info)
+            await zeroconf.async_close()
+

--- a/aioesphomeserver/climate.py
+++ b/aioesphomeserver/climate.py
@@ -1,0 +1,165 @@
+import json
+from aioesphomeapi.api_pb2 import ClimateMode, ClimateFanMode, ClimateSwingMode, ClimateAction, ClimatePreset, ClimateStateResponse, ListEntitiesClimateResponse
+from . import BasicEntity, ClimateCommandRequest
+from aiohttp import web
+from urllib import parse
+
+class ClimateEntity(BasicEntity):
+    DOMAIN = "climate"
+
+    def __init__(self, name, object_id, supported_modes, visual_min_temperature, visual_max_temperature, visual_target_temperature_step, **kwargs):
+        super().__init__(name=name, object_id=object_id, **kwargs)
+        self.supported_modes = supported_modes
+        self.visual_min_temperature = visual_min_temperature
+        self.visual_max_temperature = visual_max_temperature
+        self.visual_target_temperature_step = visual_target_temperature_step
+
+        # Initialize default values if they are not provided
+        self.mode = kwargs.get('mode', ClimateMode.CLIMATE_MODE_OFF)
+        self.target_temperature = kwargs.get('target_temperature', self.visual_min_temperature)
+        self.current_temperature = kwargs.get('current_temperature', self.visual_min_temperature)
+        self.fan_mode = kwargs.get('fan_mode', ClimateFanMode.CLIMATE_FAN_OFF)
+        self.swing_mode = kwargs.get('swing_mode', ClimateSwingMode.CLIMATE_SWING_OFF)
+        self.action = kwargs.get('action', ClimateAction.CLIMATE_ACTION_OFF)
+        self.preset = kwargs.get('preset', ClimatePreset.CLIMATE_PRESET_NONE)
+
+    async def build_list_entities_response(self):
+        return ListEntitiesClimateResponse(
+            object_id=self.object_id,
+            key=self.key,
+            name=self.name,
+            unique_id=self.unique_id,
+            supported_modes=self.supported_modes,
+            visual_min_temperature=self.visual_min_temperature,
+            visual_max_temperature=self.visual_max_temperature,
+            visual_target_temperature_step=self.visual_target_temperature_step,
+        )
+
+    async def build_state_response(self):
+        return ClimateStateResponse(
+            key=self.key,
+            mode=self.mode,
+            target_temperature=self.target_temperature,
+            current_temperature=self.current_temperature,
+            fan_mode=self.fan_mode,
+            swing_mode=self.swing_mode,
+            action=self.action,
+            preset=self.preset,
+        )
+
+    async def state_json(self):
+        state = await self.build_state_response()
+        data = {
+            "mode": state.mode,
+            "target_temperature": state.target_temperature,
+            "current_temperature": state.current_temperature,
+            "fan_mode": state.fan_mode,
+            "swing_mode": state.swing_mode,
+            "action": state.action,
+            "preset": state.preset,
+        }
+        return json.dumps(data)
+
+    async def set_state_from_command(self, command):
+        changed = False
+        if command.has_mode:
+            self.mode = command.mode
+            changed = True
+        if command.has_target_temperature:
+            self.target_temperature = command.target_temperature
+            changed = True
+        if command.has_current_temperature:
+            self.current_temperature = command.current_temperature
+            changed = True
+        if command.has_fan_mode:
+            self.fan_mode = command.fan_mode
+            changed = True
+        if command.has_swing_mode:
+            self.swing_mode = command.swing_mode
+            changed = True
+        if command.has_action:
+            self.action = command.action
+            changed = True
+        if command.has_preset:
+            self.preset = command.preset
+            changed = True
+
+        if changed:
+            await self.notify_state_change()
+
+    async def set_state_from_query(self, **query):
+        if 'target_temperature' in query:
+            self.target_temperature = float(query['target_temperature'])
+        if 'mode' in query:
+            self.mode = int(query['mode'])
+        if 'current_temperature' in query:
+            self.current_temperature = float(query['current_temperature'])
+        if 'fan_mode' in query:
+            self.fan_mode = int(query['fan_mode'])
+        if 'swing_mode' in query:
+            self.swing_mode = int(query['swing_mode'])
+        if 'action' in query:
+            self.action = int(query['action'])
+        if 'preset' in query:
+            self.preset = int(query['preset'])
+
+        await self.notify_state_change()
+
+    async def handle(self, key, message):
+        if isinstance(message, ClimateCommandRequest) and message.key == self.key:
+            await self.set_state_from_command(message)
+
+    async def add_routes(self, router):
+        router.add_route("GET", f"/climate/{self.object_id}", self.route_get_state)
+        router.add_route("POST", f"/climate/{self.object_id}/set", self.route_set_state)
+        router.add_route("POST", f"/climate/{self.object_id}/set_mode", self.route_set_mode)
+        router.add_route("POST", f"/climate/{self.object_id}/set_target_temperature", self.route_set_target_temperature)
+        router.add_route("POST", f"/climate/{self.object_id}/set_fan_mode", self.route_set_fan_mode)
+        router.add_route("POST", f"/climate/{self.object_id}/set_swing_mode", self.route_set_swing_mode)
+        router.add_route("POST", f"/climate/{self.object_id}/set_preset", self.route_set_preset)
+
+    async def route_get_state(self, request):
+        data = await self.state_json()
+        return web.Response(text=data)
+
+    async def route_set_state(self, request):
+        query = await request.json()
+        await self.set_state_from_query(**query)
+
+        data = await self.state_json()
+        return web.Response(text=data)
+
+    async def route_set_mode(self, request):
+        query = await request.json()
+        await self.set_state_from_query(mode=query.get('mode'))
+
+        data = await self.state_json()
+        return web.Response(text=data)
+
+    async def route_set_target_temperature(self, request):
+        query = await request.json()
+        await self.set_state_from_query(target_temperature=query.get('target_temperature'))
+
+        data = await self.state_json()
+        return web.Response(text=data)
+
+    async def route_set_fan_mode(self, request):
+        query = await request.json()
+        await self.set_state_from_query(fan_mode=query.get('fan_mode'))
+
+        data = await self.state_json()
+        return web.Response(text=data)
+
+    async def route_set_swing_mode(self, request):
+        query = await request.json()
+        await self.set_state_from_query(swing_mode=query.get('swing_mode'))
+
+        data = await self.state_json()
+        return web.Response(text=data)
+
+    async def route_set_preset(self, request):
+        query = await request.json()
+        await self.set_state_from_query(preset=query.get('preset'))
+
+        data = await self.state_json()
+        return web.Response(text=data)

--- a/aioesphomeserver/climate.py
+++ b/aioesphomeserver/climate.py
@@ -10,6 +10,8 @@ from aioesphomeapi import (
     ClimatePreset,
 )
 
+logger = logging.getLogger(__name__)
+
 class ClimateEntity(BasicEntity):
     DOMAIN = "climate"
 
@@ -34,7 +36,6 @@ class ClimateEntity(BasicEntity):
                  **kwargs):
         super().__init__(*args, **kwargs)
         
-        # Initialize all supported features
         self.supported_modes = supported_modes or [ClimateMode.OFF]
         self.supports_two_point_target_temperature = supports_two_point_target_temperature
         self.visual_min_temperature = visual_min_temperature
@@ -53,11 +54,12 @@ class ClimateEntity(BasicEntity):
         self.supports_preset = supports_preset
         self.supported_presets = supported_presets or []
 
-        # Initialize state values
         self.mode = self.supported_modes[0]
-        self.target_temperature = visual_min_temperature
-        self.target_temperature_low = visual_min_temperature
-        self.target_temperature_high = visual_max_temperature
+        if self.supports_two_point_target_temperature:
+            self.target_temperature_low = visual_min_temperature
+            self.target_temperature_high = visual_max_temperature
+        else:
+            self.target_temperature = visual_min_temperature
         self.current_temperature = visual_min_temperature
         self.fan_mode = self.supported_fan_modes[0] if self.supported_fan_modes else None
         self.swing_mode = self.supported_swing_modes[0] if self.supported_swing_modes else None
@@ -66,39 +68,19 @@ class ClimateEntity(BasicEntity):
         self.current_humidity = 0
         self.target_humidity = 0
 
-        logging.info(f"ClimateEntity: {self.object_id} initialized")
-        logging.info(f"ClimateEntity: {self.object_id} supports modes: {self.supported_modes}")
-        logging.info(f"ClimateEntity: {self.object_id} supports two point target temperature: {self.supports_two_point_target_temperature}")    
-        logging.info(f"ClimateEntity: {self.object_id} visual min temperature: {self.visual_min_temperature}")  
-        logging.info(f"ClimateEntity: {self.object_id} visual max temperature: {self.visual_max_temperature}")
-        logging.info(f"ClimateEntity: {self.object_id} visual target temperature step: {self.visual_target_temperature_step}")
-        logging.info(f"ClimateEntity: {self.object_id} supports fan mode: {self.supports_fan_mode}")
-        logging.info(f"ClimateEntity: {self.object_id} supported fan modes: {self.supported_fan_modes}")
-        logging.info(f"ClimateEntity: {self.object_id} supports swing mode: {self.supports_swing_mode}")
-        logging.info(f"ClimateEntity: {self.object_id} supported swing modes: {self.supported_swing_modes}")
-        logging.info(f"ClimateEntity: {self.object_id} supports action: {self.supports_action}")
-        logging.info(f"ClimateEntity: {self.object_id} supports current temperature: {self.supports_current_temperature}")
-        logging.info(f"ClimateEntity: {self.object_id} supports current humidity: {self.supports_current_humidity}")
-        logging.info(f"ClimateEntity: {self.object_id} supports target humidity: {self.supports_target_humidity}")
-        logging.info(f"ClimateEntity: {self.object_id} visual min humidity: {self.visual_min_humidity}")
-        logging.info(f"ClimateEntity: {self.object_id} visual max humidity: {self.visual_max_humidity}")
-        logging.info(f"ClimateEntity: {self.object_id} supports preset: {self.supports_preset}")
-        logging.info(f"ClimateEntity: {self.object_id} supported presets: {self.supported_presets}")
-        logging.info(f"ClimateEntity: {self.object_id} mode: {self.mode}")
-        logging.info(f"ClimateEntity: {self.object_id} target temperature: {self.target_temperature}")
-        logging.info(f"ClimateEntity: {self.object_id} target temperature low: {self.target_temperature_low}")
-        logging.info(f"ClimateEntity: {self.object_id} target temperature high: {self.target_temperature_high}")
-        logging.info(f"ClimateEntity: {self.object_id} current temperature: {self.current_temperature}")
-        logging.info(f"ClimateEntity: {self.object_id} fan mode: {self.fan_mode}")
-        logging.info(f"ClimateEntity: {self.object_id} swing mode: {self.swing_mode}")
-        logging.info(f"ClimateEntity: {self.object_id} action: {self.action}")
-        logging.info(f"ClimateEntity: {self.object_id} preset: {self.preset}")
-        logging.info(f"ClimateEntity: {self.object_id} current humidity: {self.current_humidity}")
-        logging.info(f"ClimateEntity: {self.object_id} target humidity: {self.target_humidity}")
-        
+        logger.info(f"ClimateEntity: {self.object_id} initialized with settings: "
+                    f"supported_modes={self.supported_modes}, "
+                    f"supports_two_point_target_temperature={self.supports_two_point_target_temperature}, "
+                    f"temperature_range=[{self.visual_min_temperature}, {self.visual_max_temperature}], "
+                    f"supports_fan_mode={self.supports_fan_mode}, "
+                    f"supports_swing_mode={self.supports_swing_mode}, "
+                    f"supports_action={self.supports_action}, "
+                    f"supports_current_temperature={self.supports_current_temperature}, "
+                    f"supports_humidity={self.supports_current_humidity or self.supports_target_humidity}, "
+                    f"supports_preset={self.supports_preset}")
+
     async def build_list_entities_response(self):
-        # Include all supported features
-        return ListEntitiesClimateResponse(
+        response = ListEntitiesClimateResponse(
             object_id=self.object_id,
             key=self.key,
             name=self.name,
@@ -118,16 +100,17 @@ class ClimateEntity(BasicEntity):
             visual_max_humidity=self.visual_max_humidity,
             supported_presets=self.supported_presets,
         )
+        logger.info(f"Building list entities response for {self.object_id}: {response}")
+        return response
 
     async def build_state_response(self):
-        # Include all current state values
         return ClimateStateResponse(
             key=self.key,
             mode=self.mode,
             current_temperature=self.current_temperature,
-            target_temperature=self.target_temperature,
-            target_temperature_low=self.target_temperature_low,
-            target_temperature_high=self.target_temperature_high,
+            target_temperature_low=self.target_temperature_low if self.supports_two_point_target_temperature else None,
+            target_temperature_high=self.target_temperature_high if self.supports_two_point_target_temperature else None,
+            target_temperature=None if self.supports_two_point_target_temperature else self.target_temperature,
             current_humidity=self.current_humidity,
             target_humidity=self.target_humidity,
             fan_mode=self.fan_mode,
@@ -137,13 +120,11 @@ class ClimateEntity(BasicEntity):
         )
 
     async def state_json(self):
-        # Include all relevant state information
         state = await self.build_state_response()
         data = {
             "id": self.json_id,
             "name": self.name,
             "mode": ClimateMode(state.mode).name,
-            "target_temperature": state.target_temperature,
             "current_temperature": state.current_temperature if self.supports_current_temperature else None,
             "fan_mode": ClimateFanMode(state.fan_mode).name if self.supports_fan_mode and state.fan_mode is not None else None,
             "swing_mode": ClimateSwingMode(state.swing_mode).name if self.supports_swing_mode and state.swing_mode is not None else None,
@@ -155,10 +136,11 @@ class ClimateEntity(BasicEntity):
         if self.supports_two_point_target_temperature:
             data["target_temperature_low"] = state.target_temperature_low
             data["target_temperature_high"] = state.target_temperature_high
+        else:
+            data["target_temperature"] = state.target_temperature
         return json.dumps(data)
 
     async def set_state_from_command(self, command):
-        # Handle all possible incoming commands
         changed = False
         for prop in ['mode', 'target_temperature', 'target_temperature_low', 'target_temperature_high', 'fan_mode', 'swing_mode', 'preset', 'target_humidity']:
             has_prop = f"has_{prop}"
@@ -166,7 +148,7 @@ class ClimateEntity(BasicEntity):
                 attr = getattr(command, prop)
                 current_attr = getattr(self, prop)
                 if attr != current_attr:
-                    await self.device.log(3, self.DOMAIN, f"[{self.object_id}] Setting {prop} to {attr}")
+                    logger.info(f"[{self.object_id}] Setting {prop} to {attr}")
                     setattr(self, prop, attr)
                     changed = True
 
@@ -178,14 +160,7 @@ class ClimateEntity(BasicEntity):
 
         if 'mode' in query:
             cmd.has_mode = True
-            if isinstance(query['mode'], int):
-                cmd.mode = query['mode']
-            else:
-                cmd.mode = ClimateMode[query['mode'].upper()]
-
-        if 'target_temperature' in query:
-            cmd.has_target_temperature = True
-            cmd.target_temperature = float(query['target_temperature'])
+            cmd.mode = ClimateMode[query['mode'].upper()] if isinstance(query['mode'], str) else query['mode']
 
         if self.supports_two_point_target_temperature:
             if 'target_temperature_low' in query:
@@ -194,27 +169,22 @@ class ClimateEntity(BasicEntity):
             if 'target_temperature_high' in query:
                 cmd.has_target_temperature_high = True
                 cmd.target_temperature_high = float(query['target_temperature_high'])
+        else:
+            if 'target_temperature' in query:
+                cmd.has_target_temperature = True
+                cmd.target_temperature = float(query['target_temperature'])
 
         if self.supports_fan_mode and 'fan_mode' in query:
             cmd.has_fan_mode = True
-            if isinstance(query['fan_mode'], int):
-                cmd.fan_mode = query['fan_mode']
-            else:
-                cmd.fan_mode = ClimateFanMode[query['fan_mode'].upper()]
+            cmd.fan_mode = ClimateFanMode[query['fan_mode'].upper()] if isinstance(query['fan_mode'], str) else query['fan_mode']
 
         if self.supports_swing_mode and 'swing_mode' in query:
             cmd.has_swing_mode = True
-            if isinstance(query['swing_mode'], int):
-                cmd.swing_mode = query['swing_mode']
-            else:
-                cmd.swing_mode = ClimateSwingMode[query['swing_mode'].upper()]
+            cmd.swing_mode = ClimateSwingMode[query['swing_mode'].upper()] if isinstance(query['swing_mode'], str) else query['swing_mode']
 
         if self.supports_preset and 'preset' in query:
             cmd.has_preset = True
-            if isinstance(query['preset'], int):
-                cmd.preset = query['preset']
-            else:
-                cmd.preset = ClimatePreset[query['preset'].upper()]
+            cmd.preset = ClimatePreset[query['preset'].upper()] if isinstance(query['preset'], str) else query['preset']
 
         if self.supports_target_humidity and 'target_humidity' in query:
             cmd.has_target_humidity = True
@@ -223,14 +193,14 @@ class ClimateEntity(BasicEntity):
         await self.set_state_from_command(cmd)
 
     async def add_routes(self, router):
-        # Add routes for all supported features
         router.add_route("GET", f"/climate/{self.object_id}", self.route_get_state)
         router.add_route("POST", f"/climate/{self.object_id}/set", self.route_set_state)
         router.add_route("POST", f"/climate/{self.object_id}/set_mode", self.route_set_mode)
-        router.add_route("POST", f"/climate/{self.object_id}/set_target_temperature", self.route_set_target_temperature)
         if self.supports_two_point_target_temperature:
             router.add_route("POST", f"/climate/{self.object_id}/set_target_temperature_low", self.route_set_target_temperature_low)
             router.add_route("POST", f"/climate/{self.object_id}/set_target_temperature_high", self.route_set_target_temperature_high)
+        else:
+            router.add_route("POST", f"/climate/{self.object_id}/set_target_temperature", self.route_set_target_temperature)
         if self.supports_fan_mode:
             router.add_route("POST", f"/climate/{self.object_id}/set_fan_mode", self.route_set_fan_mode)
         if self.supports_swing_mode:
@@ -240,7 +210,6 @@ class ClimateEntity(BasicEntity):
         if self.supports_target_humidity:
             router.add_route("POST", f"/climate/{self.object_id}/set_target_humidity", self.route_set_target_humidity)
 
-    # Implement the route handler methods (route_get_state, route_set_state, etc.) here
     async def route_get_state(self, request):
         data = await self.state_json()
         return web.Response(text=data)
@@ -260,6 +229,18 @@ class ClimateEntity(BasicEntity):
     async def route_set_target_temperature(self, request):
         query = await request.json()
         await self.set_state_from_query(target_temperature=query.get('target_temperature'))
+        data = await self.state_json()
+        return web.Response(text=data)
+
+    async def route_set_target_temperature_low(self, request):
+        query = await request.json()
+        await self.set_state_from_query(target_temperature_low=query.get('target_temperature_low'))
+        data = await self.state_json()
+        return web.Response(text=data)
+
+    async def route_set_target_temperature_high(self, request):
+        query = await request.json()
+        await self.set_state_from_query(target_temperature_high=query.get('target_temperature_high'))
         data = await self.state_json()
         return web.Response(text=data)
 
@@ -284,29 +265,5 @@ class ClimateEntity(BasicEntity):
     async def route_set_target_humidity(self, request):
         query = await request.json()
         await self.set_state_from_query(target_humidity=query.get('target_humidity'))
-        data = await self.state_json()
-        return web.Response(text=data)
-    
-    async def route_set_target_temperature_low(self, request):
-        query = await request.json()
-        await self.set_state_from_query(target_temperature_low=query.get('target_temperature_low'))
-        data = await self.state_json()
-        return web.Response(text=data)
-
-    async def route_set_target_temperature_high(self, request):
-        query = await request.json()
-        await self.set_state_from_query(target_temperature_high=query.get('target_temperature_high'))
-        data = await self.state_json()
-        return web.Response(text=data)
-
-    async def route_set_current_humidity(self, request):
-        query = await request.json()
-        await self.set_state_from_query(current_humidity=query.get('current_humidity'))
-        data = await self.state_json()
-        return web.Response(text=data)
-
-    async def route_set_action(self, request):
-        query = await request.json()
-        await self.set_state_from_query(action=query.get('action'))
         data = await self.state_json()
         return web.Response(text=data)

--- a/aioesphomeserver/climate.py
+++ b/aioesphomeserver/climate.py
@@ -1,29 +1,103 @@
-import json
-from aioesphomeapi.api_pb2 import ClimateMode, ClimateFanMode, ClimateSwingMode, ClimateAction, ClimatePreset, ClimateStateResponse, ListEntitiesClimateResponse
-from . import BasicEntity, ClimateCommandRequest
+from . import BasicEntity, ListEntitiesClimateResponse, ClimateStateResponse, ClimateCommandRequest
 from aiohttp import web
-from urllib import parse
+import logging
+import json
+from aioesphomeapi import (
+    ClimateMode,
+    ClimateFanMode,
+    ClimateSwingMode,
+    ClimateAction,
+    ClimatePreset,
+)
 
 class ClimateEntity(BasicEntity):
     DOMAIN = "climate"
 
-    def __init__(self, name, object_id, supported_modes, visual_min_temperature, visual_max_temperature, visual_target_temperature_step, **kwargs):
-        super().__init__(name=name, object_id=object_id, **kwargs)
-        self.supported_modes = supported_modes
+    def __init__(self, *args, 
+                 supported_modes=None,
+                 supports_two_point_target_temperature=False,
+                 visual_min_temperature=0, 
+                 visual_max_temperature=100,
+                 visual_target_temperature_step=0.1, 
+                 supports_fan_mode=False,
+                 supported_fan_modes=None,
+                 supports_swing_mode=False,
+                 supported_swing_modes=None,
+                 supports_action=False,
+                 supports_current_temperature=True,
+                 supports_current_humidity=False,
+                 supports_target_humidity=False,
+                 visual_min_humidity=0,
+                 visual_max_humidity=100,
+                 supports_preset=False,
+                 supported_presets=None,
+                 **kwargs):
+        super().__init__(*args, **kwargs)
+        
+        # Initialize all supported features
+        self.supported_modes = supported_modes or [ClimateMode.OFF]
+        self.supports_two_point_target_temperature = supports_two_point_target_temperature
         self.visual_min_temperature = visual_min_temperature
         self.visual_max_temperature = visual_max_temperature
         self.visual_target_temperature_step = visual_target_temperature_step
+        self.supports_fan_mode = supports_fan_mode
+        self.supported_fan_modes = supported_fan_modes or []
+        self.supports_swing_mode = supports_swing_mode
+        self.supported_swing_modes = supported_swing_modes or []
+        self.supports_action = supports_action
+        self.supports_current_temperature = supports_current_temperature
+        self.supports_current_humidity = supports_current_humidity
+        self.supports_target_humidity = supports_target_humidity
+        self.visual_min_humidity = visual_min_humidity
+        self.visual_max_humidity = visual_max_humidity
+        self.supports_preset = supports_preset
+        self.supported_presets = supported_presets or []
 
-        # Initialize default values if they are not provided
-        self.mode = kwargs.get('mode', ClimateMode.CLIMATE_MODE_OFF)
-        self.target_temperature = kwargs.get('target_temperature', self.visual_min_temperature)
-        self.current_temperature = kwargs.get('current_temperature', self.visual_min_temperature)
-        self.fan_mode = kwargs.get('fan_mode', ClimateFanMode.CLIMATE_FAN_OFF)
-        self.swing_mode = kwargs.get('swing_mode', ClimateSwingMode.CLIMATE_SWING_OFF)
-        self.action = kwargs.get('action', ClimateAction.CLIMATE_ACTION_OFF)
-        self.preset = kwargs.get('preset', ClimatePreset.CLIMATE_PRESET_NONE)
+        # Initialize state values
+        self.mode = self.supported_modes[0]
+        self.target_temperature = visual_min_temperature
+        self.target_temperature_low = visual_min_temperature
+        self.target_temperature_high = visual_max_temperature
+        self.current_temperature = visual_min_temperature
+        self.fan_mode = self.supported_fan_modes[0] if self.supported_fan_modes else None
+        self.swing_mode = self.supported_swing_modes[0] if self.supported_swing_modes else None
+        self.action = ClimateAction.OFF
+        self.preset = self.supported_presets[0] if self.supported_presets else None
+        self.current_humidity = 0
+        self.target_humidity = 0
 
+        logging.info(f"ClimateEntity: {self.object_id} initialized")
+        logging.info(f"ClimateEntity: {self.object_id} supports modes: {self.supported_modes}")
+        logging.info(f"ClimateEntity: {self.object_id} supports two point target temperature: {self.supports_two_point_target_temperature}")    
+        logging.info(f"ClimateEntity: {self.object_id} visual min temperature: {self.visual_min_temperature}")  
+        logging.info(f"ClimateEntity: {self.object_id} visual max temperature: {self.visual_max_temperature}")
+        logging.info(f"ClimateEntity: {self.object_id} visual target temperature step: {self.visual_target_temperature_step}")
+        logging.info(f"ClimateEntity: {self.object_id} supports fan mode: {self.supports_fan_mode}")
+        logging.info(f"ClimateEntity: {self.object_id} supported fan modes: {self.supported_fan_modes}")
+        logging.info(f"ClimateEntity: {self.object_id} supports swing mode: {self.supports_swing_mode}")
+        logging.info(f"ClimateEntity: {self.object_id} supported swing modes: {self.supported_swing_modes}")
+        logging.info(f"ClimateEntity: {self.object_id} supports action: {self.supports_action}")
+        logging.info(f"ClimateEntity: {self.object_id} supports current temperature: {self.supports_current_temperature}")
+        logging.info(f"ClimateEntity: {self.object_id} supports current humidity: {self.supports_current_humidity}")
+        logging.info(f"ClimateEntity: {self.object_id} supports target humidity: {self.supports_target_humidity}")
+        logging.info(f"ClimateEntity: {self.object_id} visual min humidity: {self.visual_min_humidity}")
+        logging.info(f"ClimateEntity: {self.object_id} visual max humidity: {self.visual_max_humidity}")
+        logging.info(f"ClimateEntity: {self.object_id} supports preset: {self.supports_preset}")
+        logging.info(f"ClimateEntity: {self.object_id} supported presets: {self.supported_presets}")
+        logging.info(f"ClimateEntity: {self.object_id} mode: {self.mode}")
+        logging.info(f"ClimateEntity: {self.object_id} target temperature: {self.target_temperature}")
+        logging.info(f"ClimateEntity: {self.object_id} target temperature low: {self.target_temperature_low}")
+        logging.info(f"ClimateEntity: {self.object_id} target temperature high: {self.target_temperature_high}")
+        logging.info(f"ClimateEntity: {self.object_id} current temperature: {self.current_temperature}")
+        logging.info(f"ClimateEntity: {self.object_id} fan mode: {self.fan_mode}")
+        logging.info(f"ClimateEntity: {self.object_id} swing mode: {self.swing_mode}")
+        logging.info(f"ClimateEntity: {self.object_id} action: {self.action}")
+        logging.info(f"ClimateEntity: {self.object_id} preset: {self.preset}")
+        logging.info(f"ClimateEntity: {self.object_id} current humidity: {self.current_humidity}")
+        logging.info(f"ClimateEntity: {self.object_id} target humidity: {self.target_humidity}")
+        
     async def build_list_entities_response(self):
+        # Include all supported features
         return ListEntitiesClimateResponse(
             object_id=self.object_id,
             key=self.key,
@@ -33,14 +107,29 @@ class ClimateEntity(BasicEntity):
             visual_min_temperature=self.visual_min_temperature,
             visual_max_temperature=self.visual_max_temperature,
             visual_target_temperature_step=self.visual_target_temperature_step,
+            supports_two_point_target_temperature=self.supports_two_point_target_temperature,
+            supported_fan_modes=self.supported_fan_modes,
+            supported_swing_modes=self.supported_swing_modes,
+            supports_current_temperature=self.supports_current_temperature,
+            supports_action=self.supports_action,
+            supports_current_humidity=self.supports_current_humidity,
+            supports_target_humidity=self.supports_target_humidity,
+            visual_min_humidity=self.visual_min_humidity,
+            visual_max_humidity=self.visual_max_humidity,
+            supported_presets=self.supported_presets,
         )
 
     async def build_state_response(self):
+        # Include all current state values
         return ClimateStateResponse(
             key=self.key,
             mode=self.mode,
-            target_temperature=self.target_temperature,
             current_temperature=self.current_temperature,
+            target_temperature=self.target_temperature,
+            target_temperature_low=self.target_temperature_low,
+            target_temperature_high=self.target_temperature_high,
+            current_humidity=self.current_humidity,
+            target_humidity=self.target_humidity,
             fan_mode=self.fan_mode,
             swing_mode=self.swing_mode,
             action=self.action,
@@ -48,76 +137,110 @@ class ClimateEntity(BasicEntity):
         )
 
     async def state_json(self):
+        # Include all relevant state information
         state = await self.build_state_response()
         data = {
-            "mode": state.mode,
+            "id": self.json_id,
+            "name": self.name,
+            "mode": ClimateMode(state.mode).name,
             "target_temperature": state.target_temperature,
-            "current_temperature": state.current_temperature,
-            "fan_mode": state.fan_mode,
-            "swing_mode": state.swing_mode,
-            "action": state.action,
-            "preset": state.preset,
+            "current_temperature": state.current_temperature if self.supports_current_temperature else None,
+            "fan_mode": ClimateFanMode(state.fan_mode).name if self.supports_fan_mode and state.fan_mode is not None else None,
+            "swing_mode": ClimateSwingMode(state.swing_mode).name if self.supports_swing_mode and state.swing_mode is not None else None,
+            "action": ClimateAction(state.action).name if self.supports_action else None,
+            "preset": ClimatePreset(state.preset).name if self.supports_preset and state.preset is not None else None,
+            "current_humidity": state.current_humidity if self.supports_current_humidity else None,
+            "target_humidity": state.target_humidity if self.supports_target_humidity else None,
         }
+        if self.supports_two_point_target_temperature:
+            data["target_temperature_low"] = state.target_temperature_low
+            data["target_temperature_high"] = state.target_temperature_high
         return json.dumps(data)
 
     async def set_state_from_command(self, command):
+        # Handle all possible incoming commands
         changed = False
-        if command.has_mode:
-            self.mode = command.mode
-            changed = True
-        if command.has_target_temperature:
-            self.target_temperature = command.target_temperature
-            changed = True
-        if command.has_current_temperature:
-            self.current_temperature = command.current_temperature
-            changed = True
-        if command.has_fan_mode:
-            self.fan_mode = command.fan_mode
-            changed = True
-        if command.has_swing_mode:
-            self.swing_mode = command.swing_mode
-            changed = True
-        if command.has_action:
-            self.action = command.action
-            changed = True
-        if command.has_preset:
-            self.preset = command.preset
-            changed = True
+        for prop in ['mode', 'target_temperature', 'target_temperature_low', 'target_temperature_high', 'fan_mode', 'swing_mode', 'preset', 'target_humidity']:
+            has_prop = f"has_{prop}"
+            if hasattr(command, has_prop) and getattr(command, has_prop):
+                attr = getattr(command, prop)
+                current_attr = getattr(self, prop)
+                if attr != current_attr:
+                    await self.device.log(3, self.DOMAIN, f"[{self.object_id}] Setting {prop} to {attr}")
+                    setattr(self, prop, attr)
+                    changed = True
 
         if changed:
             await self.notify_state_change()
 
     async def set_state_from_query(self, **query):
-        if 'target_temperature' in query:
-            self.target_temperature = float(query['target_temperature'])
+        cmd = ClimateCommandRequest(key=self.key)
+
         if 'mode' in query:
-            self.mode = int(query['mode'])
-        if 'current_temperature' in query:
-            self.current_temperature = float(query['current_temperature'])
-        if 'fan_mode' in query:
-            self.fan_mode = int(query['fan_mode'])
-        if 'swing_mode' in query:
-            self.swing_mode = int(query['swing_mode'])
-        if 'action' in query:
-            self.action = int(query['action'])
-        if 'preset' in query:
-            self.preset = int(query['preset'])
+            cmd.has_mode = True
+            if isinstance(query['mode'], int):
+                cmd.mode = query['mode']
+            else:
+                cmd.mode = ClimateMode[query['mode'].upper()]
 
-        await self.notify_state_change()
+        if 'target_temperature' in query:
+            cmd.has_target_temperature = True
+            cmd.target_temperature = float(query['target_temperature'])
 
-    async def handle(self, key, message):
-        if isinstance(message, ClimateCommandRequest) and message.key == self.key:
-            await self.set_state_from_command(message)
+        if self.supports_two_point_target_temperature:
+            if 'target_temperature_low' in query:
+                cmd.has_target_temperature_low = True
+                cmd.target_temperature_low = float(query['target_temperature_low'])
+            if 'target_temperature_high' in query:
+                cmd.has_target_temperature_high = True
+                cmd.target_temperature_high = float(query['target_temperature_high'])
+
+        if self.supports_fan_mode and 'fan_mode' in query:
+            cmd.has_fan_mode = True
+            if isinstance(query['fan_mode'], int):
+                cmd.fan_mode = query['fan_mode']
+            else:
+                cmd.fan_mode = ClimateFanMode[query['fan_mode'].upper()]
+
+        if self.supports_swing_mode and 'swing_mode' in query:
+            cmd.has_swing_mode = True
+            if isinstance(query['swing_mode'], int):
+                cmd.swing_mode = query['swing_mode']
+            else:
+                cmd.swing_mode = ClimateSwingMode[query['swing_mode'].upper()]
+
+        if self.supports_preset and 'preset' in query:
+            cmd.has_preset = True
+            if isinstance(query['preset'], int):
+                cmd.preset = query['preset']
+            else:
+                cmd.preset = ClimatePreset[query['preset'].upper()]
+
+        if self.supports_target_humidity and 'target_humidity' in query:
+            cmd.has_target_humidity = True
+            cmd.target_humidity = float(query['target_humidity'])
+
+        await self.set_state_from_command(cmd)
 
     async def add_routes(self, router):
+        # Add routes for all supported features
         router.add_route("GET", f"/climate/{self.object_id}", self.route_get_state)
         router.add_route("POST", f"/climate/{self.object_id}/set", self.route_set_state)
         router.add_route("POST", f"/climate/{self.object_id}/set_mode", self.route_set_mode)
         router.add_route("POST", f"/climate/{self.object_id}/set_target_temperature", self.route_set_target_temperature)
-        router.add_route("POST", f"/climate/{self.object_id}/set_fan_mode", self.route_set_fan_mode)
-        router.add_route("POST", f"/climate/{self.object_id}/set_swing_mode", self.route_set_swing_mode)
-        router.add_route("POST", f"/climate/{self.object_id}/set_preset", self.route_set_preset)
+        if self.supports_two_point_target_temperature:
+            router.add_route("POST", f"/climate/{self.object_id}/set_target_temperature_low", self.route_set_target_temperature_low)
+            router.add_route("POST", f"/climate/{self.object_id}/set_target_temperature_high", self.route_set_target_temperature_high)
+        if self.supports_fan_mode:
+            router.add_route("POST", f"/climate/{self.object_id}/set_fan_mode", self.route_set_fan_mode)
+        if self.supports_swing_mode:
+            router.add_route("POST", f"/climate/{self.object_id}/set_swing_mode", self.route_set_swing_mode)
+        if self.supports_preset:
+            router.add_route("POST", f"/climate/{self.object_id}/set_preset", self.route_set_preset)
+        if self.supports_target_humidity:
+            router.add_route("POST", f"/climate/{self.object_id}/set_target_humidity", self.route_set_target_humidity)
 
+    # Implement the route handler methods (route_get_state, route_set_state, etc.) here
     async def route_get_state(self, request):
         data = await self.state_json()
         return web.Response(text=data)
@@ -125,41 +248,65 @@ class ClimateEntity(BasicEntity):
     async def route_set_state(self, request):
         query = await request.json()
         await self.set_state_from_query(**query)
-
         data = await self.state_json()
         return web.Response(text=data)
 
     async def route_set_mode(self, request):
         query = await request.json()
         await self.set_state_from_query(mode=query.get('mode'))
-
         data = await self.state_json()
         return web.Response(text=data)
 
     async def route_set_target_temperature(self, request):
         query = await request.json()
         await self.set_state_from_query(target_temperature=query.get('target_temperature'))
-
         data = await self.state_json()
         return web.Response(text=data)
 
     async def route_set_fan_mode(self, request):
         query = await request.json()
         await self.set_state_from_query(fan_mode=query.get('fan_mode'))
-
         data = await self.state_json()
         return web.Response(text=data)
 
     async def route_set_swing_mode(self, request):
         query = await request.json()
         await self.set_state_from_query(swing_mode=query.get('swing_mode'))
-
         data = await self.state_json()
         return web.Response(text=data)
 
     async def route_set_preset(self, request):
         query = await request.json()
         await self.set_state_from_query(preset=query.get('preset'))
+        data = await self.state_json()
+        return web.Response(text=data)
 
+    async def route_set_target_humidity(self, request):
+        query = await request.json()
+        await self.set_state_from_query(target_humidity=query.get('target_humidity'))
+        data = await self.state_json()
+        return web.Response(text=data)
+    
+    async def route_set_target_temperature_low(self, request):
+        query = await request.json()
+        await self.set_state_from_query(target_temperature_low=query.get('target_temperature_low'))
+        data = await self.state_json()
+        return web.Response(text=data)
+
+    async def route_set_target_temperature_high(self, request):
+        query = await request.json()
+        await self.set_state_from_query(target_temperature_high=query.get('target_temperature_high'))
+        data = await self.state_json()
+        return web.Response(text=data)
+
+    async def route_set_current_humidity(self, request):
+        query = await request.json()
+        await self.set_state_from_query(current_humidity=query.get('current_humidity'))
+        data = await self.state_json()
+        return web.Response(text=data)
+
+    async def route_set_action(self, request):
+        query = await request.json()
+        await self.set_state_from_query(action=query.get('action'))
         data = await self.state_json()
         return web.Response(text=data)

--- a/aioesphomeserver/device.py
+++ b/aioesphomeserver/device.py
@@ -1,4 +1,4 @@
-from . import (  # type: ignore
+from . import (
     DeviceInfoRequest,
     DeviceInfoResponse,
 )
@@ -8,7 +8,10 @@ from .logger import format_log
 from inspect import getframeinfo, stack
 
 import asyncio
-import datetime
+import socket
+import re
+from zeroconf.asyncio import AsyncZeroconf
+from zeroconf import ServiceInfo
 
 class Device:
     def __init__(
@@ -20,17 +23,25 @@ class Device:
             project_version=None,
             manufacturer="aioesphomeserver",
             friendly_name=None,
-            suggested_area=None
+            suggested_area=None,
+            network=None,
+            board=None,
+            platform=None
     ):
         self.name = name
-        self.mac_address = mac_address or self._generate_mac_address
+        self.mac_address = mac_address or self._generate_mac_address()
         self.model = model
         self.project_name = project_name
         self.project_version = project_version
         self.manufacturer = manufacturer
         self.friendly_name = friendly_name
         self.suggested_area = suggested_area
+        self.network = network
+        self.board = board
+        self.platform = platform
         self.entities = []
+        self.zeroconf = None
+        self.service_info = None
 
     def _generate_mac_address(self):
         # https://stackoverflow.com/a/43546406
@@ -38,11 +49,22 @@ class Device:
                                             random.randint(0, 255),
                                             random.randint(0, 255))
 
+    def _get_ip_address(self):
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            s.connect(('10.254.254.254', 1))
+            ip_address = s.getsockname()[0]
+        except Exception:
+            ip_address = '127.0.0.1'
+        finally:
+            s.close()
+        return ip_address
+
     async def build_device_info_response(self):
         return DeviceInfoResponse(
-            uses_password = False,
-            name = self.name,
-            mac_address = self.mac_address,
+            uses_password=False,
+            name=self.name,
+            mac_address=self.mac_address,
         )
 
     async def log(self, level, tag, message):
@@ -54,7 +76,7 @@ class Device:
     async def publish(self, publisher, key, message):
         for entity in self.entities:
             if publisher == entity:
-                next
+                continue
             if await entity.can_handle(key, message):
                 await entity.handle(key, message)
 
@@ -79,13 +101,56 @@ class Device:
             return None
         return self.entities[key - 1]
 
-    async def run(self):
+    async def run(self, api_port, web_port):
         from . import NativeApiServer, WebServer
 
-        self.add_entity(NativeApiServer(name="_server"))
-        self.add_entity(WebServer(name="_web_server"))
+        self.api_port = api_port
+        self.web_port = web_port
+
+        self.add_entity(NativeApiServer(name="_server", port=self.api_port))
+        self.add_entity(WebServer(name="_web_server", port=self.web_port))
+
+        self.zeroconf = await self.register_zeroconf(self.api_port)
 
         async with asyncio.TaskGroup() as tg:
             for entity in self.entities:
                 if hasattr(entity, 'run'):
                     tg.create_task(entity.run())
+
+    async def register_zeroconf(self, port):
+        zeroconf = AsyncZeroconf()
+        service_type = "_esphomelib._tcp.local."
+        
+        # Replace spaces and other invalid characters with underscores
+        sanitized_name = re.sub(r'[^a-zA-Z0-9]', '_', self.name).lower()
+        
+        service_name = f"{sanitized_name}.{service_type}"
+        ip_address = self._get_ip_address()
+        hostname = f"{sanitized_name}.local."
+
+        service_info = ServiceInfo(
+            service_type,
+            service_name,
+            addresses=[socket.inet_aton(ip_address)],
+            port=port,
+            properties={
+                "network": self.network or "wifi",
+                "board": self.board or "esp01_1m",
+                "platform": self.platform or "ESP8266",
+                "mac": self.mac_address.replace(":", "").lower(),
+                "version": self.project_version,
+                "friendly_name": self.friendly_name or self.name,
+            },
+            server=hostname,
+        )
+
+        await zeroconf.async_register_service(service_info)
+        self.service_info = service_info
+        self.zeroconf = zeroconf
+
+
+
+    async def unregister_zeroconf(self):
+        if self.zeroconf and self.service_info:
+            await self.zeroconf.async_unregister_service(self.service_info)
+            await self.zeroconf.async_close()

--- a/aioesphomeserver/device.py
+++ b/aioesphomeserver/device.py
@@ -47,6 +47,8 @@ class Device:
         self.zeroconf = None
         self.service_info = None
         self.running = True
+        self.api_port = None
+        self.web_port = None
 
     def _generate_mac_address(self):
         return "02:00:00:%02x:%02x:%02x" % (random.randint(0, 255),
@@ -63,6 +65,9 @@ class Device:
         finally:
             s.close()
         return ip_address
+    
+    def get_ip_address(self):
+        return self._get_ip_address()
 
     async def build_device_info_response(self):
         return DeviceInfoResponse(
@@ -158,9 +163,7 @@ class Device:
     async def shutdown(self):
         self.running = False
         for entity in self.entities:
-            if isinstance(entity, NativeApiServer):
-                await entity.stop()
-            elif hasattr(entity, 'stop'):
+            if hasattr(entity, 'stop'):
                 await entity.stop()
         await self.unregister_zeroconf()
 
@@ -187,6 +190,11 @@ class Device:
                     "mac": self.mac_address.replace(":", "").lower(),
                     "version": self.project_version,
                     "friendly_name": self.friendly_name or self.name,
+                    "api_version": "1.5.0",  # Added from BasicEntity
+                    "manufacturer": self.manufacturer,
+                    "model": self.model,
+                    "name": self.name,
+                    "project_name": self.project_name,
                 },
                 server=hostname,
             )

--- a/aioesphomeserver/native_api_server.py
+++ b/aioesphomeserver/native_api_server.py
@@ -167,14 +167,15 @@ class NativeApiConnection:
         return -1
 
 class NativeApiServer(BasicEntity):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, port=6053, **kwargs):
         super().__init__(*args, **kwargs)
+        self.port = port
         self._clients = set()
 
     async def run(self):
-        server = await asyncio.start_server(self.handle_client, '0.0.0.0', 6053, reuse_port=True)
+        server = await asyncio.start_server(self.handle_client, '0.0.0.0', self.port)
         async with server:
-            await self.device.log(2, "api", "starting!")
+            await self.device.log(2, "api", f"starting on port {self.port}!")
             await server.start_serving()
 
             while True:

--- a/aioesphomeserver/number.py
+++ b/aioesphomeserver/number.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+
+from . import (
+    BasicEntity,
+    NumberStateResponse,
+    ListEntitiesNumberResponse,
+)
+
+class NumberEntity(BasicEntity):
+    DOMAIN = "number"
+
+    def __init__(
+            self,
+            *args,
+            min_value=None,
+            max_value=None,
+            step=None,
+            unit_of_measurement=None,
+            mode=None,
+            **kwargs
+    ):
+        super().__init__(*args, **kwargs)
+        self.min_value = min_value
+        self.max_value = max_value
+        self.step = step
+        self.unit_of_measurement = unit_of_measurement
+        self.mode = mode
+        self._state = 0.0
+
+    async def build_list_entities_response(self):
+        return ListEntitiesNumberResponse(
+            object_id=self.object_id,
+            name=self.name,
+            key=self.key,
+            unique_id=self.unique_id,
+            icon=self.icon,
+            min_value=self.min_value,
+            max_value=self.max_value,
+            step=self.step,
+            unit_of_measurement=self.unit_of_measurement,
+            mode=self.mode,
+            entity_category=self.entity_category,
+        )
+
+    async def build_state_response(self):
+        return NumberStateResponse(
+            key=self.key,
+            state=await self.get_state()
+        )
+
+    async def state_json(self):
+        state = await self.get_state()
+
+        data = {
+            "id": self.json_id,
+            "name": self.name,
+            "state": state,
+        }
+        return json.dumps(data)
+
+    async def get_state(self):
+        return self._state
+
+    async def set_state(self, val):
+        await self.device.log(3, self.DOMAIN, f"[{self.object_id}] Setting value to {val}")
+        old_state = self._state
+        self._state = val
+        if val != old_state:
+            await self.notify_state_change()
+
+# Example usage
+if __name__ == "__main__":
+    import asyncio
+    import logging
+
+    logging.basicConfig(level=logging.INFO)
+
+    class TestDevice:
+        async def log(self, level, domain, message):
+            logging.log(level, message)
+
+        async def notify_state_change(self):
+            logging.info("State changed")
+
+    async def main():
+        device = TestDevice()
+        number_entity = NumberEntity(
+            device=device,
+            name="Test Number",
+            object_id="test_number",
+            key=1,
+            unique_id="unique_test_number",
+            min_value=0.0,
+            max_value=100.0,
+            step=1.0,
+            unit_of_measurement="%",
+            mode=1,
+        )
+
+        await number_entity.set_state(50.0)
+        print(await number_entity.build_list_entities_response())
+        print(await number_entity.build_state_response())
+        print(await number_entity.state_json())
+
+    asyncio.run(main())

--- a/aioesphomeserver/web_server.py
+++ b/aioesphomeserver/web_server.py
@@ -7,8 +7,9 @@ from aiohttp_sse import sse_response
 from . import BasicEntity
 
 class WebServer(BasicEntity):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, port=8080, **kwargs):
         super().__init__(*args, **kwargs)
+        self.port = port
         self.queue = asyncio.Queue()
 
     async def index(self, _request):
@@ -55,8 +56,8 @@ class WebServer(BasicEntity):
         
         runner = web.AppRunner(app)
         await runner.setup()
-        site = web.TCPSite(runner, "0.0.0.0", 8080)
-        await self.device.log(2, "web", "starting!")
+        site = web.TCPSite(runner, '0.0.0.0', self.port)
+        await self.device.log(2, "web", f"Starting web server on port {self.port}!")
 
         await site.start()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 aioesphomeapi==24.3.0
 aiohttp==3.9.5
 aiohttp-sse==2.2.0
+colored==2.2.4
+zeroconf
+socket 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -3,60 +3,108 @@ import random
 import logging
 import sys 
 import os
+import signal
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from aioesphomeserver import Device, ClimateEntity
-from aioesphomeapi.api_pb2 import ClimateMode, ClimateFanMode, ClimateSwingMode, ClimateAction, ClimatePreset
+from aioesphomeapi.api_pb2 import (
+    ClimateMode, 
+    ClimateFanMode, 
+    ClimateSwingMode, 
+    ClimateAction, 
+    ClimatePreset,
+)
 
-# Set up logging
-logging.basicConfig(level=logging.DEBUG)
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
 
 class TestClimateEntity(ClimateEntity):
-    def __init__(self, device, name, object_id, supported_modes, visual_min_temperature, visual_max_temperature, visual_target_temperature_step, **kwargs):
-        super().__init__(name=name, object_id=object_id, supported_modes=supported_modes, visual_min_temperature=visual_min_temperature, visual_max_temperature=visual_max_temperature, visual_target_temperature_step=visual_target_temperature_step, **kwargs)
+    def __init__(self, device, name, object_id, **kwargs):
+        super().__init__(name=name, object_id=object_id, **kwargs)
         self.device = device
-        self.mode = ClimateMode.CLIMATE_MODE_OFF
-        self.target_temperature = self.visual_min_temperature
-        self.current_temperature = self.visual_min_temperature
-        self.fan_mode = ClimateFanMode.CLIMATE_FAN_OFF
-        self.swing_mode = ClimateSwingMode.CLIMATE_SWING_OFF
-        self.action = ClimateAction.CLIMATE_ACTION_OFF
-        self.preset = ClimatePreset.CLIMATE_PRESET_NONE
-        logging.debug(f'Initialized TestClimateEntity with mode {self.mode}, min_temp {self.visual_min_temperature}, max_temp {self.visual_max_temperature}')
+        self.running = True
+        logger.info(f'Initialized TestClimateEntity with name {self.name}, object_id {self.object_id}')
 
-    async def random_temperature(self):
-        while True:
-            target_temperature = random.uniform(self.visual_min_temperature, self.visual_max_temperature)
-            await self.set_state_from_query(target_temperature=target_temperature)
-            await asyncio.sleep(random.randint(5, 15))
+    async def set_state_from_query(self, **kwargs):
+        log_kwargs = {k: self.value_to_string(k, v) for k, v in kwargs.items()}
+        logger.info(f"Received command: {log_kwargs}")
+        await super().set_state_from_query(**kwargs)
 
-    async def random_mode(self):
-        while True:
-            mode = random.choice(self.supported_modes)
-            await self.set_state_from_query(mode=mode)
-            await asyncio.sleep(random.randint(10, 20))
+    def mode_to_string(self, mode):
+        return ClimateMode.Name(mode)
 
-    async def random_away(self):
-        while True:
-            away = random.choice([True, False])
-            await self.set_state_from_query(away=away)
-            await asyncio.sleep(random.randint(20, 30))
+    def fan_mode_to_string(self, fan_mode):
+        return ClimateFanMode.Name(fan_mode)
+
+    def swing_mode_to_string(self, swing_mode):
+        return ClimateSwingMode.Name(swing_mode)
+
+    def action_to_string(self, action):
+        try:
+            return ClimateAction.Name(action)
+        except ValueError:
+            return f"UNKNOWN_ACTION_{action}"
+
+    def preset_to_string(self, preset):
+        return ClimatePreset.Name(preset)
 
     async def random_values(self):
-        while True:
-            target_temperature = random.uniform(self.visual_min_temperature, self.visual_max_temperature)
-            mode = random.choice(self.supported_modes)
-            current_temperature = random.uniform(self.visual_min_temperature, self.visual_max_temperature)
-            fan_mode = random.choice([ClimateFanMode.CLIMATE_FAN_OFF, ClimateFanMode.CLIMATE_FAN_ON, ClimateFanMode.CLIMATE_FAN_AUTO])
-            swing_mode = random.choice([ClimateSwingMode.CLIMATE_SWING_OFF, ClimateSwingMode.CLIMATE_SWING_BOTH, ClimateSwingMode.CLIMATE_SWING_VERTICAL, ClimateSwingMode.CLIMATE_SWING_HORIZONTAL])
-            action = random.choice([ClimateAction.CLIMATE_ACTION_OFF, ClimateAction.CLIMATE_ACTION_COOLING, ClimateAction.CLIMATE_ACTION_HEATING, ClimateAction.CLIMATE_ACTION_IDLE])
-            preset = random.choice([ClimatePreset.CLIMATE_PRESET_NONE, ClimatePreset.CLIMATE_PRESET_HOME, ClimatePreset.CLIMATE_PRESET_AWAY])
-            await self.set_state_from_query(target_temperature=target_temperature, mode=mode, current_temperature=current_temperature, fan_mode=fan_mode, swing_mode=swing_mode, action=action, preset=preset)
+        while self.running:
+            try:
+                changes = {}
+                if random.choice([True, False]):
+                    changes['target_temperature'] = round(random.uniform(self.visual_min_temperature, self.visual_max_temperature), 1)
+                if random.choice([True, False]):
+                    changes['mode'] = random.choice(self.supported_modes)
+                if self.supports_current_temperature and random.choice([True, False]):
+                    changes['current_temperature'] = round(random.uniform(self.visual_min_temperature, self.visual_max_temperature), 1)
+                if self.supports_fan_mode and random.choice([True, False]):
+                    changes['fan_mode'] = random.choice(self.supported_fan_modes)
+                if self.supports_swing_mode and random.choice([True, False]):
+                    changes['swing_mode'] = random.choice(self.supported_swing_modes)
+                if self.supports_action and random.choice([True, False]):
+                    changes['action'] = random.choice([ClimateAction.CLIMATE_ACTION_OFF, ClimateAction.CLIMATE_ACTION_HEATING, ClimateAction.CLIMATE_ACTION_COOLING, ClimateAction.CLIMATE_ACTION_IDLE, ClimateAction.CLIMATE_ACTION_DRYING, ClimateAction.CLIMATE_ACTION_FAN])
+                if self.supports_preset and random.choice([True, False]):
+                    changes['preset'] = random.choice(self.supported_presets)
+                if self.supports_target_humidity and random.choice([True, False]):
+                    changes['target_humidity'] = round(random.uniform(self.visual_min_humidity, self.visual_max_humidity), 1)
+                if self.supports_current_humidity and random.choice([True, False]):
+                    changes['current_humidity'] = round(random.uniform(self.visual_min_humidity, self.visual_max_humidity), 1)
+                if self.supports_two_point_target_temperature and random.choice([True, False]):
+                    changes['target_temperature_low'] = round(random.uniform(self.visual_min_temperature, self.visual_max_temperature), 1)
+                    changes['target_temperature_high'] = round(random.uniform(changes['target_temperature_low'], self.visual_max_temperature), 1)
+
+                if changes:
+                    log_changes = {k: self.value_to_string(k, v) for k, v in changes.items()}
+                    logger.info(f"Applying random changes: {log_changes}")
+                    await self.set_state_from_query(**changes)
+                
+            except Exception as e:
+                logger.error(f"Error in random_values: {e}", exc_info=True)
+
             await asyncio.sleep(random.randint(5, 15))
 
+    def value_to_string(self, key, value):
+        if key == 'mode':
+            return self.mode_to_string(value)
+        elif key == 'fan_mode':
+            return self.fan_mode_to_string(value)
+        elif key == 'swing_mode':
+            return self.swing_mode_to_string(value)
+        elif key == 'action':
+            return self.action_to_string(value)
+        elif key == 'preset':
+            return self.preset_to_string(value)
+        else:
+            return str(value)
+
+    def stop(self):
+        self.running = False
+        logger.info("Stopping random value generation")
+
 async def main():
-    device = Device(name="Test Climate", mac_address="02:00:00:00:98:01")
+    device = Device(name="Test Climate", mac_address="02:01:03:22:48:01")
     climate_entity = TestClimateEntity(
         device=device,
         name="Test Climate",
@@ -65,29 +113,58 @@ async def main():
             ClimateMode.CLIMATE_MODE_OFF,
             ClimateMode.CLIMATE_MODE_HEAT,
             ClimateMode.CLIMATE_MODE_COOL,
-            ClimateMode.CLIMATE_MODE_AUTO
+            ClimateMode.CLIMATE_MODE_AUTO,
         ],
+        supports_two_point_target_temperature=True,
         visual_min_temperature=16.0,
         visual_max_temperature=30.0,
-        visual_target_temperature_step=0.5
+        visual_target_temperature_step=0.5,
+        supports_fan_mode=True,
+        supported_fan_modes=[
+            ClimateFanMode.CLIMATE_FAN_ON,
+            ClimateFanMode.CLIMATE_FAN_OFF,
+            ClimateFanMode.CLIMATE_FAN_AUTO,
+        ],
+        supports_swing_mode=True,
+        supported_swing_modes=[
+            ClimateSwingMode.CLIMATE_SWING_OFF,
+            ClimateSwingMode.CLIMATE_SWING_BOTH,
+        ],
+        supports_action=True,
+        supports_current_temperature=True,
+        supports_current_humidity=True,
+        supports_target_humidity=True,
+        visual_min_humidity=30,
+        visual_max_humidity=80,
+        supports_preset=True,
+        supported_presets=[
+            ClimatePreset.CLIMATE_PRESET_HOME,
+            ClimatePreset.CLIMATE_PRESET_AWAY,
+            ClimatePreset.CLIMATE_PRESET_BOOST,
+        ],
     )
     device.add_entity(climate_entity)
 
     # Set initial state values after creation
-    climate_entity.mode = ClimateMode.CLIMATE_MODE_OFF
-    climate_entity.target_temperature = 16.0
-    climate_entity.current_temperature = 16.0
-    climate_entity.fan_mode = ClimateFanMode.CLIMATE_FAN_OFF
-    climate_entity.swing_mode = ClimateSwingMode.CLIMATE_SWING_OFF
-    climate_entity.action = ClimateAction.CLIMATE_ACTION_OFF
-    climate_entity.preset = ClimatePreset.CLIMATE_PRESET_NONE
+    initial_state = {
+        'mode': ClimateMode.CLIMATE_MODE_OFF,
+        'target_temperature': 22.0,
+        'target_temperature_low': 20.0,
+        'target_temperature_high': 24.0,
+        'current_temperature': 21.0,
+        'fan_mode': ClimateFanMode.CLIMATE_FAN_AUTO,
+        'swing_mode': ClimateSwingMode.CLIMATE_SWING_OFF,
+        'action': ClimateAction.CLIMATE_ACTION_IDLE,
+        'preset': ClimatePreset.CLIMATE_PRESET_HOME,
+        'target_humidity': 50.0,
+        'current_humidity': 45.0,
+    }
+    await climate_entity.set_state_from_query(**initial_state)
 
-    logging.debug('Starting device...')
-    await device.run(api_port=6053, web_port=8081)
+    logger.info('Starting device...')
+    
     await asyncio.gather(
-        climate_entity.random_temperature(),
-        climate_entity.random_mode(),
-        climate_entity.random_away(),
+        device.run(api_port=6053, web_port=8081),
         climate_entity.random_values()
     )
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,0 +1,95 @@
+import asyncio
+import random
+import logging
+import sys 
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from aioesphomeserver import Device, ClimateEntity
+from aioesphomeapi.api_pb2 import ClimateMode, ClimateFanMode, ClimateSwingMode, ClimateAction, ClimatePreset
+
+# Set up logging
+logging.basicConfig(level=logging.DEBUG)
+
+class TestClimateEntity(ClimateEntity):
+    def __init__(self, device, name, object_id, supported_modes, visual_min_temperature, visual_max_temperature, visual_target_temperature_step, **kwargs):
+        super().__init__(name=name, object_id=object_id, supported_modes=supported_modes, visual_min_temperature=visual_min_temperature, visual_max_temperature=visual_max_temperature, visual_target_temperature_step=visual_target_temperature_step, **kwargs)
+        self.device = device
+        self.mode = ClimateMode.CLIMATE_MODE_OFF
+        self.target_temperature = self.visual_min_temperature
+        self.current_temperature = self.visual_min_temperature
+        self.fan_mode = ClimateFanMode.CLIMATE_FAN_OFF
+        self.swing_mode = ClimateSwingMode.CLIMATE_SWING_OFF
+        self.action = ClimateAction.CLIMATE_ACTION_OFF
+        self.preset = ClimatePreset.CLIMATE_PRESET_NONE
+        logging.debug(f'Initialized TestClimateEntity with mode {self.mode}, min_temp {self.visual_min_temperature}, max_temp {self.visual_max_temperature}')
+
+    async def random_temperature(self):
+        while True:
+            target_temperature = random.uniform(self.visual_min_temperature, self.visual_max_temperature)
+            await self.set_state_from_query(target_temperature=target_temperature)
+            await asyncio.sleep(random.randint(5, 15))
+
+    async def random_mode(self):
+        while True:
+            mode = random.choice(self.supported_modes)
+            await self.set_state_from_query(mode=mode)
+            await asyncio.sleep(random.randint(10, 20))
+
+    async def random_away(self):
+        while True:
+            away = random.choice([True, False])
+            await self.set_state_from_query(away=away)
+            await asyncio.sleep(random.randint(20, 30))
+
+    async def random_values(self):
+        while True:
+            target_temperature = random.uniform(self.visual_min_temperature, self.visual_max_temperature)
+            mode = random.choice(self.supported_modes)
+            current_temperature = random.uniform(self.visual_min_temperature, self.visual_max_temperature)
+            fan_mode = random.choice([ClimateFanMode.CLIMATE_FAN_OFF, ClimateFanMode.CLIMATE_FAN_ON, ClimateFanMode.CLIMATE_FAN_AUTO])
+            swing_mode = random.choice([ClimateSwingMode.CLIMATE_SWING_OFF, ClimateSwingMode.CLIMATE_SWING_BOTH, ClimateSwingMode.CLIMATE_SWING_VERTICAL, ClimateSwingMode.CLIMATE_SWING_HORIZONTAL])
+            action = random.choice([ClimateAction.CLIMATE_ACTION_OFF, ClimateAction.CLIMATE_ACTION_COOLING, ClimateAction.CLIMATE_ACTION_HEATING, ClimateAction.CLIMATE_ACTION_IDLE])
+            preset = random.choice([ClimatePreset.CLIMATE_PRESET_NONE, ClimatePreset.CLIMATE_PRESET_HOME, ClimatePreset.CLIMATE_PRESET_AWAY])
+            await self.set_state_from_query(target_temperature=target_temperature, mode=mode, current_temperature=current_temperature, fan_mode=fan_mode, swing_mode=swing_mode, action=action, preset=preset)
+            await asyncio.sleep(random.randint(5, 15))
+
+async def main():
+    device = Device(name="Test Climate", mac_address="02:00:00:00:98:01")
+    climate_entity = TestClimateEntity(
+        device=device,
+        name="Test Climate",
+        object_id="test_climate",
+        supported_modes=[
+            ClimateMode.CLIMATE_MODE_OFF,
+            ClimateMode.CLIMATE_MODE_HEAT,
+            ClimateMode.CLIMATE_MODE_COOL,
+            ClimateMode.CLIMATE_MODE_AUTO
+        ],
+        visual_min_temperature=16.0,
+        visual_max_temperature=30.0,
+        visual_target_temperature_step=0.5
+    )
+    device.add_entity(climate_entity)
+
+    # Set initial state values after creation
+    climate_entity.mode = ClimateMode.CLIMATE_MODE_OFF
+    climate_entity.target_temperature = 16.0
+    climate_entity.current_temperature = 16.0
+    climate_entity.fan_mode = ClimateFanMode.CLIMATE_FAN_OFF
+    climate_entity.swing_mode = ClimateSwingMode.CLIMATE_SWING_OFF
+    climate_entity.action = ClimateAction.CLIMATE_ACTION_OFF
+    climate_entity.preset = ClimatePreset.CLIMATE_PRESET_NONE
+
+    logging.debug('Starting device...')
+    await device.run(api_port=6053, web_port=8081)
+    await asyncio.gather(
+        climate_entity.random_temperature(),
+        climate_entity.random_mode(),
+        climate_entity.random_away(),
+        climate_entity.random_values()
+    )
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_climate_a.py
+++ b/tests/test_climate_a.py
@@ -3,17 +3,13 @@ import random
 import logging
 import sys 
 import os
-import signal
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from aioesphomeserver import Device, ClimateEntity
 from aioesphomeapi.api_pb2 import (
     ClimateMode, 
-    ClimateFanMode, 
-    ClimateSwingMode, 
-    ClimateAction, 
-    ClimatePreset,
+    ClimateAction,
 )
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
@@ -34,20 +30,11 @@ class TestClimateEntity(ClimateEntity):
     def mode_to_string(self, mode):
         return ClimateMode.Name(mode)
 
-    def fan_mode_to_string(self, fan_mode):
-        return ClimateFanMode.Name(fan_mode)
-
-    def swing_mode_to_string(self, swing_mode):
-        return ClimateSwingMode.Name(swing_mode)
-
     def action_to_string(self, action):
         try:
             return ClimateAction.Name(action)
         except ValueError:
             return f"UNKNOWN_ACTION_{action}"
-
-    def preset_to_string(self, preset):
-        return ClimatePreset.Name(preset)
 
     async def random_values(self):
         while self.running:
@@ -57,23 +44,12 @@ class TestClimateEntity(ClimateEntity):
                     changes['target_temperature'] = round(random.uniform(self.visual_min_temperature, self.visual_max_temperature), 1)
                 if random.choice([True, False]):
                     changes['mode'] = random.choice(self.supported_modes)
-                if self.supports_current_temperature and random.choice([True, False]):
+                if random.choice([True, False]):
                     changes['current_temperature'] = round(random.uniform(self.visual_min_temperature, self.visual_max_temperature), 1)
-                if self.supports_fan_mode and random.choice([True, False]):
-                    changes['fan_mode'] = random.choice(self.supported_fan_modes)
-                if self.supports_swing_mode and random.choice([True, False]):
-                    changes['swing_mode'] = random.choice(self.supported_swing_modes)
-                if self.supports_action and random.choice([True, False]):
-                    changes['action'] = random.choice([ClimateAction.CLIMATE_ACTION_OFF, ClimateAction.CLIMATE_ACTION_HEATING, ClimateAction.CLIMATE_ACTION_COOLING, ClimateAction.CLIMATE_ACTION_IDLE, ClimateAction.CLIMATE_ACTION_DRYING, ClimateAction.CLIMATE_ACTION_FAN])
-                if self.supports_preset and random.choice([True, False]):
-                    changes['preset'] = random.choice(self.supported_presets)
-                if self.supports_target_humidity and random.choice([True, False]):
-                    changes['target_humidity'] = round(random.uniform(self.visual_min_humidity, self.visual_max_humidity), 1)
-                if self.supports_current_humidity and random.choice([True, False]):
-                    changes['current_humidity'] = round(random.uniform(self.visual_min_humidity, self.visual_max_humidity), 1)
-                if self.supports_two_point_target_temperature and random.choice([True, False]):
-                    changes['target_temperature_low'] = round(random.uniform(self.visual_min_temperature, self.visual_max_temperature), 1)
-                    changes['target_temperature_high'] = round(random.uniform(changes['target_temperature_low'], self.visual_max_temperature), 1)
+                if random.choice([True, False]):
+                    changes['action'] = random.choice([ClimateAction.CLIMATE_ACTION_OFF, ClimateAction.CLIMATE_ACTION_HEATING, ClimateAction.CLIMATE_ACTION_IDLE])
+                if random.choice([True, False]):
+                    changes['current_humidity'] = round(random.uniform(0, 100), 1)
 
                 if changes:
                     log_changes = {k: self.value_to_string(k, v) for k, v in changes.items()}
@@ -88,14 +64,8 @@ class TestClimateEntity(ClimateEntity):
     def value_to_string(self, key, value):
         if key == 'mode':
             return self.mode_to_string(value)
-        elif key == 'fan_mode':
-            return self.fan_mode_to_string(value)
-        elif key == 'swing_mode':
-            return self.swing_mode_to_string(value)
         elif key == 'action':
             return self.action_to_string(value)
-        elif key == 'preset':
-            return self.preset_to_string(value)
         else:
             return str(value)
 
@@ -104,7 +74,7 @@ class TestClimateEntity(ClimateEntity):
         logger.info("Stopping random value generation")
 
 async def main():
-    device = Device(name="Test Climate", mac_address="22:01:43:22:48:01")
+    device = Device(name="Test Climate", mac_address="22:01:43:22:48:02")
     climate_entity = TestClimateEntity(
         device=device,
         name="Test Climate",
@@ -112,36 +82,17 @@ async def main():
         supported_modes=[
             ClimateMode.CLIMATE_MODE_OFF,
             ClimateMode.CLIMATE_MODE_HEAT,
-            ClimateMode.CLIMATE_MODE_COOL,
-            ClimateMode.CLIMATE_MODE_AUTO,
         ],
-        supports_two_point_target_temperature=True,
+        supports_two_point_target_temperature=False,
         visual_min_temperature=16.0,
         visual_max_temperature=30.0,
         visual_target_temperature_step=0.5,
-        supports_fan_mode=True,
-        supported_fan_modes=[
-            ClimateFanMode.CLIMATE_FAN_ON,
-            ClimateFanMode.CLIMATE_FAN_OFF,
-            ClimateFanMode.CLIMATE_FAN_AUTO,
-        ],
-        supports_swing_mode=True,
-        supported_swing_modes=[
-            ClimateSwingMode.CLIMATE_SWING_OFF,
-            ClimateSwingMode.CLIMATE_SWING_BOTH,
-        ],
+        supports_fan_mode=False,
+        supports_swing_mode=False,
         supports_action=True,
         supports_current_temperature=True,
         supports_current_humidity=True,
-        supports_target_humidity=True,
-        visual_min_humidity=30,
-        visual_max_humidity=80,
-        supports_preset=True,
-        supported_presets=[
-            ClimatePreset.CLIMATE_PRESET_HOME,
-            ClimatePreset.CLIMATE_PRESET_AWAY,
-            ClimatePreset.CLIMATE_PRESET_BOOST,
-        ],
+        supports_target_humidity=False,
     )
     device.add_entity(climate_entity)
 
@@ -149,14 +100,8 @@ async def main():
     initial_state = {
         'mode': ClimateMode.CLIMATE_MODE_OFF,
         'target_temperature': 22.0,
-        'target_temperature_low': 20.0,
-        'target_temperature_high': 24.0,
         'current_temperature': 21.0,
-        'fan_mode': ClimateFanMode.CLIMATE_FAN_AUTO,
-        'swing_mode': ClimateSwingMode.CLIMATE_SWING_OFF,
         'action': ClimateAction.CLIMATE_ACTION_IDLE,
-        'preset': ClimatePreset.CLIMATE_PRESET_HOME,
-        'target_humidity': 50.0,
         'current_humidity': 45.0,
     }
     await climate_entity.set_state_from_query(**initial_state)

--- a/tests/test_dimmer.py
+++ b/tests/test_dimmer.py
@@ -1,0 +1,75 @@
+import asyncio
+import logging
+import random
+import sys 
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from aioesphomeserver import Device, LightEntity, LightCommandRequest
+from aioesphomeapi import LightColorCapability
+
+# Set up logging
+logging.basicConfig(level=logging.INFO)
+
+class RandomDimmer(LightEntity):
+    def __init__(self, name):
+        super().__init__(name=name, color_modes=[LightColorCapability.BRIGHTNESS])
+
+    async def random_dimmer(self):
+        while True:
+            brightness = random.uniform(0, 1)  # Set brightness as a float between 0 and 1
+            logging.info(f"Setting dimmer {self.name} brightness to {brightness * 100:.2f}%")
+            command = LightCommandRequest(
+                key=self.key,
+                has_state=True,
+                state=True,
+                has_brightness=True,
+                brightness=brightness
+            )
+            await self.set_state_from_command(command)
+            await asyncio.sleep(5)
+
+    async def handle(self, key, message):
+        if isinstance(message, LightCommandRequest):
+            if message.key == self.key:
+                logging.info(f"Received command for {self.name}: {message}")
+                await self.set_state_from_command(message)
+
+async def run_device(name, api_port, web_port):
+    logging.info(f"Setting up {name} with API port {api_port} and Web port {web_port}")
+
+    mac_address = f"AC:BC:32:89:0E:{api_port:02x}"
+
+    device = Device(
+        name=name,
+        mac_address=mac_address,
+        model="Test Device",
+        project_name="aioesphomeserver",
+        project_version="1.0.0",
+        network="wifi",
+        board="esp01_1m",
+        platform="ESP8266"
+    )
+
+    # Add a LightEntity configured as a dimmer with random changes
+    dimmer = RandomDimmer(name=f"{name} Dimmer")
+    device.add_entity(dimmer)
+
+    # Run the random dimmer functionality
+    asyncio.create_task(dimmer.random_dimmer())
+
+    try:
+        # Run the device
+        await device.run(api_port, web_port)
+    finally:
+        await device.unregister_zeroconf()
+
+async def main():
+    # Define a single device
+    name, api_port, web_port = "Test Device", 6053, 8081
+    await run_device(name, api_port, web_port)
+
+if __name__ == "__main__":
+    logging.info("Starting main event loop")
+    asyncio.run(main())

--- a/tests/test_ip.py
+++ b/tests/test_ip.py
@@ -1,0 +1,18 @@
+import socket
+
+def get_ip_address():
+    # Create a socket object
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        # Connect to an external IP address (doesn't need to be reachable)
+        s.connect(('10.254.254.254', 1))
+        ip_address = s.getsockname()[0]
+    except Exception:
+        ip_address = '127.0.0.1'
+    finally:
+        s.close()
+    return ip_address
+
+if __name__ == "__main__":
+    ip_address = get_ip_address()
+    print(f"The IP address of this machine is: {ip_address}")

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,119 @@
+import asyncio
+import logging
+import random
+import sys 
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from aioesphomeserver import Device, SwitchEntity, LightEntity
+from aioesphomeserver.light import LightCommandRequest
+
+# Set up logging
+logging.basicConfig(level=logging.INFO)
+
+class ToggleSwitch(SwitchEntity):
+    def __init__(self, name):
+        super().__init__(name=name)
+        self._state = False
+
+    async def toggle(self):
+        try:
+            while True:
+                self._state = not self._state
+                logging.info(f"Toggling switch {self.name} to {'ON' if self._state else 'OFF'}")
+                await self.set_state(self._state)
+                await asyncio.sleep(5)
+        except asyncio.CancelledError:
+            logging.warning(f"ToggleSwitch {self.name} was cancelled")
+            raise
+
+    async def set_state(self, state):
+        self._state = state
+        await self.device.log(3, self.DOMAIN, f"[{self.object_id}] Setting state to {state}")
+        await self.notify_state_change()
+
+class RandomDimmer(LightEntity):
+    def __init__(self, name):
+        super().__init__(name=name)
+        self._state = False
+
+    async def random_dimmer(self):
+        try:
+            while True:
+                brightness = random.uniform(0, 1)  # Set brightness as a float between 0 and 1
+                logging.info(f"Setting dimmer {self.name} brightness to {brightness * 100:.2f}%")
+                command = LightCommandRequest(
+                    key=self.key,
+                    has_state=True,
+                    state=True,
+                    has_brightness=True,
+                    brightness=brightness
+                )
+                await self.set_state_from_command(command)
+                await asyncio.sleep(5)
+        except asyncio.CancelledError:
+            logging.warning(f"RandomDimmer {self.name} was cancelled")
+            raise
+
+async def run_device(name, api_port, web_port):
+    logging.info(f"Setting up {name} with API port {api_port} and Web port {web_port}")
+
+    mac_address = f"AC:BC:32:89:0E:{api_port:02x}"
+
+    device = Device(
+        name=name,
+        mac_address=mac_address,  # Ensure unique MAC address
+        model="Test Device",
+        project_name="aioesphomeserver",
+        project_version="1.0.0",
+        network="wifi",
+        board="esp01_1m",
+        platform="ESP8266"
+    )
+
+    test_switch = ToggleSwitch(name=f"{name} Switch")
+    device.add_entity(test_switch)
+
+    # Add a LightEntity configured as a dimmer with random changes
+    dimmer = RandomDimmer(name=f"{name} Dimmer")
+    device.add_entity(dimmer)
+
+    # Run the toggle functionality
+    toggle_task = asyncio.create_task(test_switch.toggle())
+
+    # Run the random dimmer functionality
+    dimmer_task = asyncio.create_task(dimmer.random_dimmer())
+
+    try:
+        # Run the device
+        await device.run(api_port, web_port)
+    except asyncio.CancelledError:
+        logging.warning(f"Device {name} run was cancelled")
+        toggle_task.cancel()
+        dimmer_task.cancel()
+        raise
+    finally:
+        await device.unregister_zeroconf()
+
+async def main():
+    devices = [
+        ("Test Device 1", 6053, 8081),
+        ("Test Device 2", 6054, 8082),
+        ("Test Device 3", 6055, 8083),
+        ("Test Device 4", 6056, 8084),
+        ("Test Device 5", 6057, 8085),
+        ("Test Device 6", 6058, 8086),
+        ("Test Device 7", 6059, 8087),
+        ("Test Device 8", 6060, 8088),
+        ("Test Device 9", 6061, 8089),
+        ("Test Device 10", 6062, 8090),
+    ]
+    await asyncio.gather(*(run_device(name, api_port, web_port) for name, api_port, web_port in devices))
+
+if __name__ == "__main__":
+    logging.info("Starting main event loop")
+    try:
+        asyncio.run(main())
+    except asyncio.CancelledError:
+        logging.info("Main event loop was cancelled")

--- a/tests/test_zeroconf.py
+++ b/tests/test_zeroconf.py
@@ -1,0 +1,35 @@
+from zeroconf import ServiceBrowser, Zeroconf, ServiceInfo
+
+class MyListener:
+    def add_service(self, zeroconf, service_type, name):
+        info = zeroconf.get_service_info(service_type, name)
+        if info:
+            self.log_service_info("added", name, info)
+
+    def remove_service(self, zeroconf, service_type, name):
+        print(f"Service {name} removed")
+
+    def update_service(self, zeroconf, service_type, name):
+        info = zeroconf.get_service_info(service_type, name)
+        if info:
+            self.log_service_info("updated", name, info)
+
+    def log_service_info(self, action, name, info):
+        addresses = ["%s:%d" % (address, info.port) for address in info.parsed_addresses()]
+        properties = info.properties
+        print(f"Service {name} {action}:")
+        print(f"  Addresses: {addresses}")
+        print(f"  Server: {info.server}")
+        print(f"  Properties:")
+        for key, value in properties.items():
+            if value is not None:
+                print(f"    {key.decode('utf-8')}: {value.decode('utf-8')}")
+
+zeroconf = Zeroconf()
+listener = MyListener()
+browser = ServiceBrowser(zeroconf, "_esphomelib._tcp.local.", listener)
+
+try:
+    input("Press enter to exit...\n\n")
+finally:
+    zeroconf.close()


### PR DESCRIPTION
Zeroconf support is now entirely in the device class. 

Added more error handling to the native api server and improved reconnection logic. Will need more testing.

Added number entity - did not add webserver support

Added climate entity - did not add webserver support, not fully tested

